### PR TITLE
get-spacing test refactor

### DIFF
--- a/mocks/kitchen-sink.json
+++ b/mocks/kitchen-sink.json
@@ -6,96 +6,6 @@
     "monospace-font-family": null,
     "wysiwyg-block-images": true
   },
-  "wysiwyg": {
-    "scope": "wysiwyg",
-    "elements": {
-      "h1": "h1",
-      "h2": "h2",
-      "h3": "h3",
-      "h4": "h4",
-      "h5": "h5",
-      "h6": "h6",
-      "lede": ["&.with-lede > p:first-child", "blockquote > p"],
-      "para": ["p", "ul", "ol", "dl"],
-      "small": "small",
-      "caption": "figcaption"
-    },
-    "spacing": {
-      "vertical-rhythm": {
-        "include": [
-          "h1",
-          "h2",
-          "h3",
-          "h4",
-          "h5",
-          "h6",
-          "p",
-          "ul",
-          "ol",
-          "dl",
-          "blockquote",
-          "figure",
-          "pre"
-        ],
-        "breakpoints": {
-          "default": {
-            "block": "1rem"
-          },
-          "large": {
-            "block": "1.5rem"
-          }
-        }
-      },
-      "larger-headings": {
-        "include": ["h1", "h2"],
-        "breakpoints": {
-          "default": {
-            "block-start": "3rem"
-          },
-          "large": {
-            "block-start": "5rem"
-          }
-        }
-      },
-      "smaller-headings": {
-        "include": ["h3", "h4", "h5", "h6"],
-        "breakpoints": {
-          "default": {
-            "block-start": "2rem"
-          },
-          "large": {
-            "block-start": "3rem"
-          }
-        }
-      },
-      "other-content": {
-        "include": [
-          "pre",
-          "iframe",
-          "figure",
-          "& > img",
-          "blockquote",
-          "& > p > img:first-child:last-child",
-          "& > p > .gatsby-resp-image-wrapper"
-        ],
-        "breakpoints": {
-          "default": {
-            "block": "3rem"
-          },
-          "large": {
-            "block": "4rem"
-          }
-        }
-      }
-    }
-  },
-  "prefixes": {
-    "typography": "type",
-    "custom-properties": "type",
-    "sass-mixins": "type",
-    "sass-tokens": "type"
-  },
-  "format-version": 1,
   "breakpoints": {
     "large": "768px"
   },
@@ -280,6 +190,89 @@
       }
     }
   },
+  "wysiwyg": {
+    "scope": "wysiwyg",
+    "elements": {
+      "h1": "h1",
+      "h2": "h2",
+      "h3": "h3",
+      "h4": "h4",
+      "h5": "h5",
+      "h6": "h6",
+      "lede": ["&.with-lede > p:first-child", "blockquote > p"],
+      "para": ["p", "ul", "ol", "dl"],
+      "small": "small",
+      "caption": "figcaption"
+    },
+    "spacing": {
+      "vertical-rhythm": {
+        "include": [
+          "h1",
+          "h2",
+          "h3",
+          "h4",
+          "h5",
+          "h6",
+          "p",
+          "ul",
+          "ol",
+          "dl",
+          "blockquote",
+          "figure",
+          "pre"
+        ],
+        "breakpoints": {
+          "default": {
+            "block": "1rem"
+          },
+          "large": {
+            "block": "1.5rem"
+          }
+        }
+      },
+      "larger-headings": {
+        "include": ["h1", "h2"],
+        "breakpoints": {
+          "default": {
+            "block-start": "3rem"
+          },
+          "large": {
+            "block-start": "5rem"
+          }
+        }
+      },
+      "smaller-headings": {
+        "include": ["h3", "h4", "h5", "h6"],
+        "breakpoints": {
+          "default": {
+            "block-start": "2rem"
+          },
+          "large": {
+            "block-start": "3rem"
+          }
+        }
+      },
+      "other-content": {
+        "include": [
+          "pre",
+          "iframe",
+          "figure",
+          "& > img",
+          "blockquote",
+          "& > p > img:first-child:last-child",
+          "& > p > .gatsby-resp-image-wrapper"
+        ],
+        "breakpoints": {
+          "default": {
+            "block": "3rem"
+          },
+          "large": {
+            "block": "4rem"
+          }
+        }
+      }
+    }
+  },
   "inline-elements": {
     "a": {
       "include": ".type-link",
@@ -307,5 +300,12 @@
         "radius": "0.25rem"
       }
     }
-  }
+  },
+  "prefixes": {
+    "typography": "type",
+    "custom-properties": "type",
+    "sass-mixins": "type",
+    "sass-tokens": "type"
+  },
+  "format-version": 1
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "start": "node cli --config mocks/demo-site.yml --output public/typebeast --no-sourcemap --no-sass --compression compressed",
     "test": "jest",
     "build": "yarn start",
-    "cli:minimum": "node cli --config mocks/minimum.yml --output build/minimum",
-    "cli:demo-site": "node cli --config mocks/demo-site.yml --output build/demo-site",
-    "cli:kitchen-sink": "node cli --config mocks/kitchen-sink.yml --output build/kitchen-sink"
+    "cli:minimum": "node cli --json --config mocks/minimum.yml --output build/minimum",
+    "cli:demo-site": "node cli --json --config mocks/demo-site.yml --output build/demo-site",
+    "cli:kitchen-sink": "node cli --json --config mocks/kitchen-sink.yml --output build/kitchen-sink"
   },
   "repository": {
     "type": "git",

--- a/src/get-spacing.js
+++ b/src/get-spacing.js
@@ -2,10 +2,7 @@ const { transform } = require('./transform-spacing')
 const { write } = require('./write-spacing')
 
 function get(merged) {
-  return write({
-    transformed: transform(merged),
-    config: merged,
-  })
+  return write(transform(merged))
 }
 
 module.exports = { get }

--- a/src/get-spacing.test.js
+++ b/src/get-spacing.test.js
@@ -1,50 +1,54 @@
 const { get } = require('./get-spacing')
-const mock = require('../mocks/demo-site.json')
+const mox = {
+  default: require('../mocks/minimum.json'),
+  kitchenSink: require('../mocks/kitchen-sink.json'),
+}
 
-describe('get()', () => {
-  test('it works', async () => {
-    const spacing = get(mock)
-    expect(spacing).toMatchInlineSnapshot(`
-      "// vertical-rhythm
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6,
-      p,
-      ul,
-      ol,
-      dl,
-      blockquote,
-      figure,
-      pre {
-        margin-block-start: 0;
-        margin-block-end: 0;
-      }
+test('write spacing rules for minimum config', async () => {
+  expect(get(mox.default)).toMatchInlineSnapshot(`""`)
+})
 
-      // horizontal-reset
-      figure,
-      blockquote,
-      dd {
-        margin-inline-start: 0;
-        margin-inline-end: 0;
-      }
+test('write spacing rules for minimum config', async () => {
+  expect(get(mox.kitchenSink)).toMatchInlineSnapshot(`
+    "// group: vertical-rhythm
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    ul,
+    ol,
+    dl,
+    blockquote,
+    figure,
+    pre {
+      margin-block-start: 0;
+      margin-block-end: 0;
+    }
 
-      // horizontal-rule
+    // group: horizontal-reset
+    figure,
+    blockquote,
+    dd {
+      margin-inline-start: 0;
+      margin-inline-end: 0;
+    }
+
+    // group: horizontal-rule
+    hr {
+      margin-block-start: 3rem;
+      margin-block-end: 3rem;
+    }
+
+    @media screen and (min-width: 768px) {
+      // group: horizontal-rule
       hr {
-        margin-block-start: 3rem;
-        margin-block-end: 3rem;
+        margin-block-start: 4rem;
+        margin-block-end: 4rem;
       }
-
-      @media screen and (min-width: 768px) {
-        // horizontal-rule
-        hr {
-          margin-block-start: 4rem;
-          margin-block-end: 4rem;
-        }
-      }
-      "
-    `)
-  })
+    }
+    "
+  `)
 })

--- a/src/get-wysiwyg-spacing.test.js
+++ b/src/get-wysiwyg-spacing.test.js
@@ -1,0 +1,122 @@
+const { get } = require('./get-wysiwyg-spacing')
+const mox = {
+  default: require('../mocks/minimum.json'),
+  kitchenSink: require('../mocks/kitchen-sink.json'),
+}
+
+test('write wysiwyg spacing rules for minimum config', async () => {
+  expect(get(mox.default)).toMatchInlineSnapshot(`""`)
+})
+
+test('write wysiwyg spacing rules for minimum config', async () => {
+  expect(get(mox.kitchenSink)).toMatchInlineSnapshot(`
+    ".wysiwyg {
+      // ----------------------------------------
+      // breakpoint: default
+      // ----------------------------------------
+
+      // group: vertical-rhythm
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      p,
+      ul,
+      ol,
+      dl,
+      blockquote,
+      figure,
+      pre {
+        margin-block-start: 1rem;
+        margin-block-end: 1rem;
+      }
+
+      // group: larger-headings
+
+      h1,
+      h2 {
+        margin-block-start: 3rem;
+      }
+
+      // group: smaller-headings
+
+      h3,
+      h4,
+      h5,
+      h6 {
+        margin-block-start: 2rem;
+      }
+
+      // group: other-content
+
+      pre,
+      iframe,
+      figure,
+      & > img,
+      blockquote,
+      & > p > img:first-child:last-child,
+      & > p > .gatsby-resp-image-wrapper {
+        margin-block-start: 3rem;
+        margin-block-end: 3rem;
+      }
+
+      @include typebeast-break-min(768px) {
+        // ----------------------------------------
+        // breakpoint: large
+        // ----------------------------------------
+
+        // group: vertical-rhythm
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p,
+        ul,
+        ol,
+        dl,
+        blockquote,
+        figure,
+        pre {
+          margin-block-start: 1.5rem;
+          margin-block-end: 1.5rem;
+        }
+
+        // group: larger-headings
+
+        h1,
+        h2 {
+          margin-block-start: 5rem;
+        }
+
+        // group: smaller-headings
+
+        h3,
+        h4,
+        h5,
+        h6 {
+          margin-block-start: 3rem;
+        }
+
+        // group: other-content
+
+        pre,
+        iframe,
+        figure,
+        & > img,
+        blockquote,
+        & > p > img:first-child:last-child,
+        & > p > .gatsby-resp-image-wrapper {
+          margin-block-start: 4rem;
+          margin-block-end: 4rem;
+        }
+      }
+    }
+    "
+  `)
+})

--- a/src/transform-spacing.js
+++ b/src/transform-spacing.js
@@ -44,13 +44,16 @@ function getDataByBreakpoint(data) {
 
 function transform(config) {
   const { spacing = {} } = config
-  return Object.keys(spacing).reduce(
-    (all, groupName) => ({
-      ...all,
-      [groupName]: getDataByBreakpoint(spacing[groupName]),
-    }),
-    {}
-  )
+  return {
+    breakpoints: config.breakpoints || {},
+    spacing: Object.keys(spacing || {}).reduce(
+      (all, groupName) => ({
+        ...all,
+        [groupName]: getDataByBreakpoint(spacing[groupName]),
+      }),
+      {}
+    ),
+  }
 }
 
 module.exports = { transform }

--- a/src/transform-spacing.test.js
+++ b/src/transform-spacing.test.js
@@ -2,9 +2,13 @@ const { transform } = require('./transform-spacing')
 
 describe('transform()', () => {
   test('is optional', () => {
-    expect(transform({})).toEqual({})
-    expect(transform({ 'format-version': 1 })).toEqual({})
-    expect(transform({ spacing: {} })).toEqual({})
+    const empty = { breakpoints: {}, spacing: {} }
+    expect(transform({})).toEqual(empty)
+    expect(transform({ 'format-version': 1 })).toEqual(empty)
+    expect(transform({ spacing: null })).toEqual(empty)
+    expect(transform({ spacing: {} })).toEqual(empty)
+    expect(transform({ breakpoints: null })).toEqual(empty)
+    expect(transform({ breakpoints: {} })).toEqual(empty)
   })
   test('empty group', () => {
     expect(
@@ -15,7 +19,33 @@ describe('transform()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "vertical-reset": Object {},
+        "breakpoints": Object {},
+        "spacing": Object {
+          "vertical-reset": Object {},
+        },
+      }
+    `)
+  })
+  test('pass-through breakpoints', () => {
+    expect(
+      transform({
+        breakpoints: {
+          medium: 420,
+          large: '690em',
+        },
+        spacing: {
+          'vertical-reset': {},
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "breakpoints": Object {
+          "large": "690em",
+          "medium": 420,
+        },
+        "spacing": Object {
+          "vertical-reset": Object {},
+        },
       }
     `)
   })
@@ -37,15 +67,18 @@ describe('transform()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "vertical-reset": Object {
-          "default": Object {
-            "properties": Object {
-              "margin-block-end": 2,
-              "margin-block-start": 1,
-              "margin-inline-end": 4,
-              "margin-inline-start": 3,
+        "breakpoints": Object {},
+        "spacing": Object {
+          "vertical-reset": Object {
+            "default": Object {
+              "properties": Object {
+                "margin-block-end": 2,
+                "margin-block-start": 1,
+                "margin-inline-end": 4,
+                "margin-inline-start": 3,
+              },
+              "selectors": Array [],
             },
-            "selectors": Array [],
           },
         },
       }
@@ -67,15 +100,18 @@ describe('transform()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "vertical-reset": Object {
-          "default": Object {
-            "properties": Object {
-              "margin-block-end": 1,
-              "margin-block-start": 1,
-              "margin-inline-end": 2,
-              "margin-inline-start": 2,
+        "breakpoints": Object {},
+        "spacing": Object {
+          "vertical-reset": Object {
+            "default": Object {
+              "properties": Object {
+                "margin-block-end": 1,
+                "margin-block-start": 1,
+                "margin-inline-end": 2,
+                "margin-inline-start": 2,
+              },
+              "selectors": Array [],
             },
-            "selectors": Array [],
           },
         },
       }
@@ -99,15 +135,18 @@ describe('transform()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "vertical-reset": Object {
-          "default": Object {
-            "properties": Object {
-              "margin-block-end": 2,
-              "margin-block-start": 1,
-              "margin-inline-end": 1,
-              "margin-inline-start": 2,
+        "breakpoints": Object {},
+        "spacing": Object {
+          "vertical-reset": Object {
+            "default": Object {
+              "properties": Object {
+                "margin-block-end": 2,
+                "margin-block-start": 1,
+                "margin-inline-end": 1,
+                "margin-inline-start": 2,
+              },
+              "selectors": Array [],
             },
-            "selectors": Array [],
           },
         },
       }
@@ -128,13 +167,16 @@ describe('transform()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "vertical-reset": Object {
-          "large": Object {
-            "properties": Object {
-              "margin-block-end": 0,
-              "margin-block-start": 0,
+        "breakpoints": Object {},
+        "spacing": Object {
+          "vertical-reset": Object {
+            "large": Object {
+              "properties": Object {
+                "margin-block-end": 0,
+                "margin-block-start": 0,
+              },
+              "selectors": Array [],
             },
-            "selectors": Array [],
           },
         },
       }
@@ -162,29 +204,32 @@ describe('transform()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "vertical-reset": Object {
-          "default": Object {
-            "properties": Object {
-              "margin-block-end": 0,
-              "margin-block-start": 0,
+        "breakpoints": Object {},
+        "spacing": Object {
+          "vertical-reset": Object {
+            "default": Object {
+              "properties": Object {
+                "margin-block-end": 0,
+                "margin-block-start": 0,
+              },
+              "selectors": Array [],
             },
-            "selectors": Array [],
-          },
-          "large": Object {
-            "properties": Object {
-              "margin-block-end": 2,
-              "margin-block-start": 2,
-              "margin-inline-end": 2,
-              "margin-inline-start": 2,
+            "large": Object {
+              "properties": Object {
+                "margin-block-end": 2,
+                "margin-block-start": 2,
+                "margin-inline-end": 2,
+                "margin-inline-start": 2,
+              },
+              "selectors": Array [],
             },
-            "selectors": Array [],
-          },
-          "medium": Object {
-            "properties": Object {
-              "margin-inline-end": 1,
-              "margin-inline-start": 1,
+            "medium": Object {
+              "properties": Object {
+                "margin-inline-end": 1,
+                "margin-inline-start": 1,
+              },
+              "selectors": Array [],
             },
-            "selectors": Array [],
           },
         },
       }
@@ -206,15 +251,18 @@ describe('transform()', () => {
       })
     ).toMatchInlineSnapshot(`
       Object {
-        "vertical-reset": Object {
-          "default": Object {
-            "properties": Object {
-              "margin-block-end": 0,
-              "margin-block-start": 0,
+        "breakpoints": Object {},
+        "spacing": Object {
+          "vertical-reset": Object {
+            "default": Object {
+              "properties": Object {
+                "margin-block-end": 0,
+                "margin-block-start": 0,
+              },
+              "selectors": Array [
+                "#bruh",
+              ],
             },
-            "selectors": Array [
-              "#bruh",
-            ],
           },
         },
       }
@@ -241,17 +289,20 @@ test('can use multiple selectors', () => {
     })
   ).toMatchInlineSnapshot(`
     Object {
-      "vertical-reset": Object {
-        "default": Object {
-          "properties": Object {
-            "margin-block-end": 0,
-            "margin-block-start": 0,
+      "breakpoints": Object {},
+      "spacing": Object {
+        "vertical-reset": Object {
+          "default": Object {
+            "properties": Object {
+              "margin-block-end": 0,
+              "margin-block-start": 0,
+            },
+            "selectors": Array [
+              "#bruh",
+              "strong",
+              "&.something .compound[selector=\\"yeah\\"]",
+            ],
           },
-          "selectors": Array [
-            "#bruh",
-            "strong",
-            "&.something .compound[selector=\\"yeah\\"]",
-          ],
         },
       },
     }

--- a/src/write-spacing.js
+++ b/src/write-spacing.js
@@ -3,34 +3,34 @@ const { breakpointToMediaQuery, objectToCssProperties } = require('./utils')
 
 const writeStyleDeclaration = ({ body, selectors, group }) => {
   return `
-  // ${group}
+  // group: ${group}
   ${selectors.join(', ')} {
     ${body};
   }`
 }
 
-function createDeclarationWriter({ transformed }) {
+function createDeclarationWriter(spacing) {
   return breakpointName =>
-    Object.keys(transformed)
-      .filter(styleName => transformed[styleName][breakpointName])
+    Object.keys(spacing)
+      .filter(styleName => spacing[styleName][breakpointName])
       .map(styleName => ({
         group: styleName,
-        selectors: transformed[styleName][breakpointName].selectors,
+        selectors: spacing[styleName][breakpointName].selectors,
         body: objectToCssProperties(
-          transformed[styleName][breakpointName].properties
+          spacing[styleName][breakpointName].properties
         ),
       }))
       .map(writeStyleDeclaration)
 }
 
-function write({ transformed, config }) {
-  const declarationWriter = createDeclarationWriter({ transformed })
+function write(transformed) {
+  const declarationWriter = createDeclarationWriter(transformed.spacing)
   const defaultDeclarations = declarationWriter('default')
-  const breakpointDeclarations = Object.keys(config.breakpoints).reduce(
+  const breakpointDeclarations = Object.keys(transformed.breakpoints).reduce(
     (acc, name) => [
       ...acc,
       '\n',
-      breakpointToMediaQuery(config.breakpoints[name]) + '{',
+      breakpointToMediaQuery(transformed.breakpoints[name]) + '{',
       ...declarationWriter(name),
       '}',
     ],


### PR DESCRIPTION
- Add testing of kitchen sink and minimum configs
- Refactor output for consistency
- Fix key errors with minimal config
- Remove need for transformed data and config file in writer — include everything in the transformed data